### PR TITLE
chore: add AI workflow structure and prompt pack

### DIFF
--- a/.claude/agents/docs-curator.md
+++ b/.claude/agents/docs-curator.md
@@ -1,0 +1,16 @@
+---
+name: docs-curator
+description: Review and align project docs when workflow, architecture, or conventions change. Use PROACTIVELY for documentation-heavy diffs.
+tools: Read, Glob, Grep
+model: haiku
+memory: project
+skills:
+  - cross-model-workflow
+color: cyan
+---
+
+Review documentation changes with a narrow scope:
+
+- keep `AGENTS.md`, `CLAUDE.md`, `README.md`, `REVIEW.md`, and `plans/` aligned
+- check whether architecture or ownership docs need updates after workflow changes
+- flag duplicated or contradictory instructions across agent-facing files

--- a/.claude/agents/qwik-ui-reviewer.md
+++ b/.claude/agents/qwik-ui-reviewer.md
@@ -1,0 +1,18 @@
+---
+name: qwik-ui-reviewer
+description: Review Qwik UI changes for DaisyUI usage, accessibility, i18n coverage, and project conventions. Use PROACTIVELY for UI-heavy diffs.
+tools: Read, Glob, Grep
+model: haiku
+memory: project
+skills:
+  - qwik-aesthetic-core
+color: magenta
+---
+
+Review UI-related changes with a narrow scope:
+
+- prefer DaisyUI primitives over custom rebuilds
+- check theme-token usage instead of hardcoded colors
+- check accessibility labels and keyboard behavior
+- check i18n coverage for new visible strings
+- flag React-style patterns that do not belong in Qwik

--- a/.claude/commands/execute-plan.md
+++ b/.claude/commands/execute-plan.md
@@ -1,0 +1,13 @@
+---
+description: Execute a reviewed plan from plans/ phase by phase, keeping docs and verification in sync.
+model: sonnet
+---
+
+When invoked:
+
+1. Read the requested plan in `plans/`.
+2. Confirm the next unchecked task and affected files before editing.
+3. Implement one phase at a time.
+4. Update the plan when tasks or assumptions change.
+5. If the plan breaks, revise it before continuing.
+6. Run fresh verification before claiming success.

--- a/.claude/commands/plan-feature.md
+++ b/.claude/commands/plan-feature.md
@@ -1,0 +1,12 @@
+---
+description: Create or refresh a durable implementation plan in plans/ before non-trivial work.
+model: sonnet
+---
+
+When invoked:
+
+1. Read `AGENTS.md`, `CLAUDE.md`, and `plans/README.md`.
+2. Explore the relevant code before proposing work.
+3. Write or update `plans/<task-slug>.md` with the minimum structure from `plans/README.md`.
+4. Assume the next step is Codex plan review unless the user says otherwise.
+5. Do not edit application files unless the user explicitly asks to continue.

--- a/.claude/commands/verify-change.md
+++ b/.claude/commands/verify-change.md
@@ -1,0 +1,12 @@
+---
+description: Verify changed work with fresh evidence before completion claims or PR preparation.
+model: haiku
+---
+
+When invoked:
+
+1. Inspect the diff and determine the touched surfaces.
+2. Always run `bun run biome`.
+3. For code, config, CI, or build-affecting changes, run `bun run verify`.
+4. Cross-check `REVIEW.md`.
+5. Report only what fresh command output proves.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,18 @@
+{
+	"$schema": "https://json.schemastore.org/claude-code-settings.json",
+	"plansDirectory": "./plans",
+	"respectGitignore": true,
+	"enableAllProjectMcpServers": true,
+	"permissions": {
+		"defaultMode": "acceptEdits",
+		"allow": [],
+		"ask": [
+			"Bash(git push*)",
+			"Bash(git reset*)",
+			"Bash(rm *)",
+			"Bash(docker *)",
+			"Bash(gcloud *)"
+		],
+		"deny": []
+	}
+}

--- a/.claude/skills/cross-model-workflow/SKILL.md
+++ b/.claude/skills/cross-model-workflow/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: cross-model-workflow
+description: Shared workflow for Claude Code planning and implementation with Codex review and verification.
+---
+
+# Cross-Model Workflow
+
+Read `plans/README.md` and `.codex/README.md`.
+
+Use this skill when the task needs the default two-model loop:
+
+- Claude Code plans and implements
+- Codex reviews plans and verifies results
+- plans live in `plans/`
+- verification must be fresh

--- a/.claude/skills/qwik-aesthetic-core/SKILL.md
+++ b/.claude/skills/qwik-aesthetic-core/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: qwik-aesthetic-core
+description: Project-specific guidance for Qwik, DaisyUI, i18n, Supabase loaders, and verification in Aesthetic Lab.
+---
+
+# Qwik Aesthetic Core
+
+Read `AGENTS.md` first, then the relevant `.github/*.md` guide for the files you are touching.
+
+Use this skill for application-code work that needs a fast reminder of the repo’s core rules:
+
+- Qwik, not React
+- DaisyUI first
+- `inlineTranslate()` with `@@`
+- loaders in route files
+- fresh verification before completion

--- a/.codex/README.md
+++ b/.codex/README.md
@@ -1,0 +1,15 @@
+# Codex Workflow
+
+Codex is the second-model reviewer in this repository.
+
+## Use Codex For
+
+- reviewing plans in `plans/` against the actual codebase
+- appending `## Codex Findings` instead of rewriting the plan
+- verifying implementation with fresh command output
+
+## Read First
+
+- `AGENTS.md`
+- `plans/README.md`
+- `REVIEW.md`

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,2 @@
+# Project-local Codex defaults are intentionally minimal.
+# Keep durable workflow guidance in `.codex/README.md` and shared policy in `AGENTS.md`.

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -7,7 +7,7 @@ on:
       - "**"
 
 jobs:
-  quality:
+  lint:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,5 +1,5 @@
 # .github/workflows/lint.yml
-name: Lint Check
+name: Quality Check
 
 on:
   pull_request:
@@ -7,40 +7,26 @@ on:
       - "**"
 
 jobs:
-  lint:
+  quality:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
 
-      - name: Check for lintable files
-        id: check_files
-        run: |
-          LINTABLE=$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.sha }} -- '*.ts' '*.tsx' '*.js' '*.jsx' '*.json' '*.css' || true)
-          if [ -z "$LINTABLE" ]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "No lintable files changed — skipping lint."
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-            echo "Lintable files found:"
-            echo "$LINTABLE"
-          fi
-
       - name: Setup Bun
-        if: steps.check_files.outputs.skip != 'true'
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
       - name: Install dependencies
-        if: steps.check_files.outputs.skip != 'true'
-        run: bun install
+        run: bun install --frozen-lockfile
 
-      - name: Run Linter (Biome)
-        if: steps.check_files.outputs.skip != 'true'
+      - name: Run Biome
         run: bun run biome
 
-      - name: Lint skipped (docs-only change)
-        if: steps.check_files.outputs.skip == 'true'
-        run: echo "✅ No source files changed — lint passed."
+      - name: Run Type Check
+        run: bun run build.types
+
+      - name: Run Production Build
+        run: bun run build

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,12 @@
 # Development
 node_modules
 *.local
+.claude/settings.local.json
+.claude/*.local.json
+.claude/*.local.toml
+.codex/local.toml
+.codex/*.local.toml
+tmp/
 
 # Cache
 .cache
@@ -17,6 +23,7 @@ tsconfig.tsbuildinfo
 # Logs
 logs
 *.log
+qwik-speak-inline.log
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+	"mcpServers": {
+		"playwright": {
+			"command": "npx",
+			"args": ["-y", "@playwright/mcp"]
+		},
+		"context7": {
+			"command": "npx",
+			"args": ["-y", "@upstash/context7-mcp"]
+		}
+	}
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,26 +11,20 @@ Aesthetic Lab — Qwik City marketing site for a nail/beauty studio in Leuven, B
 | Install | `bun install` |
 | Dev server | `bun run dev` or `make dev` |
 | Production build | `bun run build` |
+| Type check | `bun run build.types` |
 | Lint/format | `bun run biome` |
+| Verify | `bun run verify` |
 | Extract i18n keys | `bun run qwik-speak-extract` |
 | Docker build+push | `make docker-build-push TAG=<tag>` |
 | Deploy Cloud Run | `make gcloud-deploy TAG=<tag>` |
 
-## Tech Stack & Versions
+## Tech Stack
 
-| Dependency | Version | Notes |
-|------------|---------|-------|
-| Qwik / Qwik City | ^1.19.x | Framework — always use latest 1.x |
-| Tailwind CSS | v4.x | CSS-first config via `src/global.css` |
-| DaisyUI | v5.x | Component library — **mandatory for all UI** |
-| Bun | latest | Runtime + package manager |
-| Vite | 7.x | Build tool |
-| Biome | ^2.x | Linter/formatter — replaces ESLint+Prettier |
-| qwik-speak | ^0.23.x | i18n |
-| Supabase SSR | ^0.6.x | Server-side data |
-| TypeScript | 5.4.x | Strict mode on |
-
-> **Rule:** When adding or upgrading dependencies, always target the latest stable version. Check changelogs for breaking changes before bumping majors.
+- Qwik / Qwik City 1.x
+- Tailwind CSS v4 + DaisyUI 5
+- Bun + Vite 7 + Biome 2
+- qwik-speak + Supabase SSR + TypeScript strict mode
+- When adding or upgrading dependencies, use the latest stable version and check changelogs before major bumps.
 
 ## Architecture
 
@@ -49,7 +43,10 @@ src/
 │   └── ui/                           # Reusable UI primitives (FadeUp, Booking, etc.)
 ├── shared/                           # Utilities (Supabase client, cookie consent, etc.)
 ├── constants/                        # Static metadata, nav config
+├── .claude/                          # Claude Code commands, skills, agents, shared settings
+├── .codex/                           # Codex workflow docs and local configuration
 ├── media/                            # Images and SVGs (vite ?jsx imports)
+├── plans/                            # Shared planning artifacts for Claude Code + Codex workflow
 ├── types.ts                          # Shared TypeScript interfaces
 ├── consts.ts                         # Formatting helpers, GA ID, booking URL
 ├── global.css                        # Tailwind + DaisyUI theme + animations
@@ -70,6 +67,9 @@ src/
 | `global.css` | Theme tokens, animations, DaisyUI plugin config |
 | `types.ts` | All shared data interfaces |
 | `speak-config.ts` | Locale definitions (add new locales here) |
+| `.claude/settings.json` | Shared Claude Code defaults and project-local permissions |
+| `.claude/commands/*` | Claude Code workflow entrypoints for planning, execution, and verification |
+| `plans/*` | Durable task plans and implementation specs reviewed by Claude Code and Codex |
 
 ## Critical Conventions
 
@@ -151,6 +151,12 @@ Key rules:
 - Run `bun run biome` before committing.
 - Husky + lint-staged auto-run Biome on staged files.
 - `biome-ignore` comments require justification.
+
+### AI Agent Workflow
+
+- For non-trivial changes, create or update a plan in `plans/` before implementation.
+- Default loop: Claude Code plans and implements, Codex reviews and verifies.
+- Keep shared agent behavior in `.claude/`, project-local Codex guidance in `.codex/`, and workflow docs aligned.
 
 ### Accessibility
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,47 +1,34 @@
 # CLAUDE.md
 
-This is the entry point for Claude-based AI agents working on the Aesthetic Lab project.
+This is the Claude Code entry point for this repository.
 
-## Quick Reference
+## Read First
 
-Read `AGENTS.md` for the full project context, conventions, and rules. For deeper topics, see the skill files in `.github/`:
+1. `AGENTS.md`
+2. `plans/README.md`
+3. `REVIEW.md`
+4. The relevant `.github/*.md` guide for the files you are touching
 
-| File | Topic |
-|------|-------|
-| `AGENTS.md` | Project snapshot, architecture, all critical conventions, anti-patterns |
-| `.github/CODING_STANDARDS.md` | Qwik patterns, TypeScript rules, formatting, imports |
-| `.github/DAISYUI_PATTERNS.md` | DaisyUI 5 component usage, theme tokens, z-index scale |
-| `.github/I18N_GUIDE.md` | Qwik Speak translation patterns, locale management |
-| `.github/DATA_LOADING.md` | Supabase routeLoader$ patterns, error handling, caching |
-| `.github/COMPONENT_GUIDE.md` | Section vs UI components, FadeUp/Booking usage, new component checklist |
-| `.github/DEPLOYMENT.md` | Build pipeline, Docker, Cloud Run, CI/CD |
+## Default Workflow
 
-## Essential Rules (Do Not Skip)
+- Use `plans/` for non-trivial work.
+- Claude Code plans and implements.
+- Codex reviews plans and verifies results.
+- Keep `AGENTS.md`, `README.md`, `REVIEW.md`, and `plans/` aligned when workflow files change.
 
-1. **DaisyUI 5 is mandatory** for all UI — buttons, modals, cards, dropdowns, ratings, etc. Reference: https://daisyui.com/components/
-2. **Use latest stable versions** of all packages. Never install outdated or deprecated dependencies.
-3. **Qwik only** — no React hooks (`useState`, `useEffect`, `useRef`). Use `component$`, `useSignal`, `useTask$`, `$()`.
-4. **Translations** use `inlineTranslate()` with `t("app.section.key@@Default English")` pattern. Never skip the `@@` fallback.
-5. **Data loading** happens in `routeLoader$` inside `layout.tsx` — never in components.
-6. **Theme colors** use DaisyUI tokens (`bg-primary`, `text-base-content`) — never hardcode hex values.
-7. **Biome** is the linter/formatter — not ESLint or Prettier. Run `bun run biome` before committing.
+## AI Surface
 
-## Commands
+- `.claude/commands/`
+- `.claude/skills/`
+- `.claude/agents/`
+- `.codex/README.md`
+- `.mcp.json`
 
-```sh
-bun install                  # Install dependencies
-bun run dev                  # Dev server (SSR mode)
-bun run build                # Production build
-bun run biome                # Lint + format
-bun run qwik-speak-extract   # Extract new translation keys
-```
+## Key Commands
 
-## Self-Improvement Protocol
-
-When working on this project, update the documentation:
-
-- **New pattern discovered** → append to the relevant `.github/*.md` file.
-- **New dependency added** → verify it's latest stable, update `AGENTS.md` tech stack table.
-- **Convention violated causing a bug** → add to the Anti-Patterns section in `AGENTS.md`.
-- **New DaisyUI component introduced** → document in `.github/DAISYUI_PATTERNS.md`.
-- **Significant refactor** → update the architecture section in `AGENTS.md`.
+- `bun run dev`
+- `bun run biome`
+- `bun run build.types`
+- `bun run build`
+- `bun run verify`
+- `bun run qwik-speak-extract`

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Aesthetic Lab | Qwik + DaisyUI
 
-A premium web application for Aesthetic Lab, built with Qwik and styled with modern Vanilla CSS and DaisyUI.
+A multilingual marketing site for Aesthetic Lab, built with Qwik City and styled with Tailwind CSS v4 plus DaisyUI 5.
 
 ## 🚀 Tech Stack
 
 - **Framework**: [Qwik](https://qwik.dev/)
-- **Styling**: [DaisyUI](https://daisyui.com/) + TailwindCSS / Vanilla CSS
+- **Styling**: [DaisyUI](https://daisyui.com/) + Tailwind CSS v4 (CSS-first config)
 - **Data**: [Supabase](https://supabase.com/)
 - **Runtime**: [Bun](https://bun.sh/)
 - **Linter/Formatter**: [Biome](https://biomejs.dev/)
@@ -18,6 +18,8 @@ A premium web application for Aesthetic Lab, built with Qwik and styled with mod
 - **Premium Design**: Modern aesthetic with DaisyUI components.
 
 ## 🛠️ Local Development
+
+Before making changes, read [AGENTS.md](AGENTS.md) for project conventions and [CLAUDE.md](CLAUDE.md) for the AI-agent entrypoint.
 
 ### Prerequisites
 
@@ -56,6 +58,14 @@ A premium web application for Aesthetic Lab, built with Qwik and styled with mod
 - `make lint`: Run Biome checks.
 - `make clean`: Reset node_modules and build artifacts.
 
+## AI Workflow
+
+- Start non-trivial work with a plan in `plans/`.
+- Let Claude Code handle planning and implementation.
+- Let Codex handle plan review and final verification.
+
+See [CLAUDE.md](CLAUDE.md), [plans/README.md](plans/README.md), and [REVIEW.md](REVIEW.md).
+
 ## 📦 Deployment
 
 The project includes a `Dockerfile` and a `Makefile` target for deploying to Google Cloud Run:
@@ -67,4 +77,4 @@ make gcloud-deploy TAG=v1.0.0
 
 ## 📜 License
 
-MIT — see [LICENSE](file:///Users/evfedoto/Documents/Projects/qwik-aestheticlab/LICENSE) file for details.
+MIT — see [LICENSE](LICENSE) for details.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,7 @@
+# Review Guidelines
+
+- New visible strings must use `inlineTranslate()` with `@@`.
+- UI changes should follow DaisyUI + Qwik conventions from `AGENTS.md`.
+- Loader changes stay in route files and return safe fallbacks.
+- Workflow changes must keep `AGENTS.md`, `CLAUDE.md`, `README.md`, and `plans/` aligned.
+- Skip formatting-only noise and non-contradictory markdown nits.

--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,7 @@
         "qwik-speak": "^0.23.2",
         "typescript": "5.4.5",
         "typescript-plugin-css-modules": "latest",
-        "undici": "^7.24.5",
+        "undici": "^7.24.6",
         "vite": "7.1.11",
         "vite-tsconfig-paths": "^4.3.2",
       },

--- a/bun.lock
+++ b/bun.lock
@@ -6,18 +6,18 @@
       "name": "aestheticlab",
       "dependencies": {
         "@supabase/ssr": "^0.6.1",
-        "@tailwindcss/vite": "^4.2.1",
+        "@tailwindcss/vite": "^4.2.2",
         "@types/luxon": "^3.7.1",
-        "tailwindcss": "^4.2.1",
+        "tailwindcss": "^4.2.2",
         "tailwindcss-animate": "^1.0.7",
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.4.7",
+        "@biomejs/biome": "^2.4.9",
         "@builder.io/qwik": "^1.19.2",
         "@builder.io/qwik-city": "^1.19.2",
         "@ditadi/qwik-hooks": "^0.1.6",
         "@qwikest/icons": "^0.0.13",
-        "@types/bun": "^1.3.10",
+        "@types/bun": "^1.3.11",
         "@types/node": "20.19.0",
         "autoprefixer": "^10.4.27",
         "class-variance-authority": "^0.7.1",
@@ -29,7 +29,7 @@
         "qwik-speak": "^0.23.2",
         "typescript": "5.4.5",
         "typescript-plugin-css-modules": "latest",
-        "undici": "^7.24.4",
+        "undici": "^7.24.5",
         "vite": "7.1.11",
         "vite-tsconfig-paths": "^4.3.2",
       },
@@ -821,7 +821,7 @@
 
     "typescript-plugin-css-modules": ["typescript-plugin-css-modules@5.2.0", "", { "dependencies": { "@types/postcss-modules-local-by-default": "^4.0.2", "@types/postcss-modules-scope": "^3.0.4", "dotenv": "^16.4.2", "icss-utils": "^5.1.0", "less": "^4.2.0", "lodash.camelcase": "^4.3.0", "postcss": "^8.4.35", "postcss-load-config": "^3.1.4", "postcss-modules-extract-imports": "^3.0.0", "postcss-modules-local-by-default": "^4.0.4", "postcss-modules-scope": "^3.1.1", "reserved-words": "^0.1.2", "sass": "^1.70.0", "source-map-js": "^1.0.2", "tsconfig-paths": "^4.2.0" }, "optionalDependencies": { "stylus": "^0.62.0" }, "peerDependencies": { "typescript": ">=4.0.0" } }, "sha512-c5pAU5d+m3GciDr/WhkFldz1NIEGBafuP/3xhFt9BEXS2gmn/LvjkoZ11vEBIuP8LkXfPNhOt1BUhM5efFuwOw=="],
 
-    "undici": ["undici@7.24.5", "", {}, "sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q=="],
+    "undici": ["undici@7.24.6", "", {}, "sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA=="],
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 

--- a/docs/prompt-pack.md
+++ b/docs/prompt-pack.md
@@ -1,0 +1,285 @@
+# Prompt Pack
+
+Reusable prompts for this repository.
+
+Read these first before using the pack:
+
+- `CLAUDE.md`
+- `AGENTS.md`
+- `plans/README.md`
+- `REVIEW.md`
+
+These prompts are designed for the current workflow:
+
+- Claude Code plans and implements
+- Codex reviews plans and verifies results
+
+## Planning Prompt For Claude Code
+
+```text
+Read CLAUDE.md, AGENTS.md, and plans/README.md first.
+
+Goal:
+[Describe the change you want.]
+
+Scope:
+- [files or areas in scope]
+- [user-visible behavior in scope]
+
+Out of scope:
+- [things that must not change]
+
+Constraints:
+- Follow AGENTS.md exactly.
+- Keep Qwik patterns only, no React patterns.
+- Use DaisyUI primitives and theme tokens.
+- Keep routeLoader$ logic in route/layout files.
+- Keep user-facing strings compatible with qwik-speak.
+- Avoid duplicated policy or unnecessary new docs.
+
+Deliverable:
+Create or update a durable plan at:
+plans/[task-slug].md
+
+Plan requirements:
+- goal
+- scope / non-goals
+- assumptions
+- small ordered tasks
+- verification
+- risks or follow-ups
+
+Do not implement yet unless I explicitly ask.
+```
+
+## Plan Review Prompt For Codex
+
+```text
+Read AGENTS.md, REVIEW.md, and plans/README.md first.
+
+Review this plan against the actual codebase:
+plans/[task-slug].md
+
+Rules:
+- Inspect the real files before judging the plan.
+- Do not rewrite the original phases.
+- Append a section titled:
+## Codex Findings
+- Add only missing steps, risks, sequencing fixes, verification gaps, or convention conflicts.
+- Flag any conflict with AGENTS.md, current repo structure, or existing workflows.
+
+Output:
+1. Update the plan file.
+2. Summarize the top 3 highest-risk findings.
+```
+
+## Implementation Prompt For Claude Code
+
+```text
+Read CLAUDE.md, AGENTS.md, plans/[task-slug].md, and any relevant .github guide first.
+
+Execute the next phase from:
+plans/[task-slug].md
+
+Constraints:
+- Stay within scope.
+- Do not silently expand the task.
+- If assumptions break, update the plan before continuing.
+- Keep instructions lean and avoid duplicate docs.
+- If workflow files change, keep AGENTS.md, CLAUDE.md, README.md, REVIEW.md, and plans/ aligned.
+
+Deliverable:
+Implement only the next planned phase and summarize:
+- files changed
+- what was completed
+- any plan updates
+- residual risks
+
+Before claiming success:
+run fresh verification evidence appropriate to the change.
+```
+
+## Verification Prompt For Codex
+
+```text
+Read AGENTS.md, REVIEW.md, and plans/[task-slug].md first.
+
+Verify the implementation against:
+plans/[task-slug].md
+
+Check:
+- required files were changed
+- repo conventions were preserved
+- no duplicated or contradictory workflow guidance was introduced
+- docs stayed aligned if workflow/config files changed
+- the implementation matches the approved plan
+
+Verification:
+- Run bun run biome
+- If code/config/CI/build behavior changed, run bun run verify
+- Report only what fresh command output proves
+
+Output:
+- pass/fail status
+- concrete findings with file references
+- residual risks if no blocking issues exist
+```
+
+## Small Bugfix Prompt
+
+```text
+Read CLAUDE.md and AGENTS.md first.
+
+Fix this issue:
+[bug description]
+
+Scope:
+- likely files: [path1], [path2]
+- keep the change minimal
+
+Constraints:
+- preserve current architecture
+- no unrelated refactors
+- follow Qwik, DaisyUI, i18n, and loader rules from AGENTS.md
+
+Deliverable:
+- fix the bug
+- explain root cause briefly
+- run the smallest relevant verification plus bun run biome
+```
+
+## UI Change Prompt
+
+```text
+Read AGENTS.md, .github/DAISYUI_PATTERNS.md, and .github/COMPONENT_GUIDE.md first.
+
+Goal:
+[describe the UI change]
+
+Scope:
+- component(s): [paths]
+- route(s): [paths]
+
+Constraints:
+- DaisyUI 5 first
+- use theme tokens, no hardcoded colors
+- Qwik only
+- all visible strings must stay translatable
+- preserve mobile-first behavior
+- do not invent a new component pattern if an existing one fits
+
+Deliverable:
+Implement the UI change and summarize:
+- reused patterns
+- any new translation keys
+- accessibility considerations
+
+Verification:
+Run bun run biome and any additional checks relevant to the UI change.
+```
+
+## Loader / Supabase Change Prompt
+
+```text
+Read AGENTS.md and .github/DATA_LOADING.md first.
+
+Goal:
+[describe the data-loading change]
+
+Scope:
+- route or layout files: [paths]
+- dependent UI files: [paths]
+
+Constraints:
+- all server data loading stays in route files
+- components receive props only
+- handle errors safely
+- locale field mapping stays in loaders
+- no data-fetching logic moved into UI components
+
+Deliverable:
+Implement the change and summarize:
+- query changes
+- fallback behavior
+- any type/interface updates
+
+Verification:
+Run bun run verify
+```
+
+## Docs Alignment Prompt
+
+```text
+Read AGENTS.md, CLAUDE.md, REVIEW.md, and plans/README.md first.
+
+Task:
+Audit and align the repo’s workflow and agent-facing docs.
+
+Check:
+- AGENTS.md is the canonical policy
+- CLAUDE.md is a thin entrypoint
+- README.md is onboarding-oriented
+- REVIEW.md contains review-only guidance
+- plans/README.md contains planning workflow only
+- .claude and .codex files do not duplicate policy unnecessarily
+
+Deliverable:
+Make the smallest edits needed to reduce duplication and contradiction.
+
+Verification:
+Run bun run biome
+```
+
+## New Feature Prompt
+
+```text
+Read CLAUDE.md, AGENTS.md, and plans/README.md first.
+
+Goal:
+Add [feature name].
+
+Scope:
+- in scope: [routes/components/docs/config]
+- out of scope: [unrelated pages, infra, redesigns]
+
+Constraints:
+- create a plan first
+- follow repo conventions exactly
+- prefer extending existing patterns over adding new abstractions
+- document only what is truly new
+
+Deliverable:
+1. Write plans/[feature-slug].md
+2. Wait for review before implementation
+```
+
+## Refactor Prompt
+
+```text
+Read CLAUDE.md, AGENTS.md, and the relevant .github guides first.
+
+Goal:
+Refactor [target] to improve [clarity / duplication / maintainability].
+
+Constraints:
+- no behavior change unless explicitly required
+- no broad cleanup outside touched scope
+- preserve current architectural boundaries
+- reduce duplication, not increase abstraction for its own sake
+
+Deliverable:
+- explain current problem briefly
+- make the refactor
+- note any doc updates required
+
+Verification:
+Run bun run verify
+```
+
+## Good Habits
+
+- Name the deliverable file.
+- Say what is out of scope.
+- Tell the agent whether it is planning, implementing, reviewing, or verifying.
+- Require fresh verification.
+- Keep prompts short and let `AGENTS.md` carry the stable rules.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 		"build.preview": "vite build --ssr src/entry.preview.tsx",
 		"build.server": "vite build -c adapters/bun/vite.config.ts",
 		"build.types": "tsc --incremental --noEmit",
+		"verify": "bun run biome && bun run build.types && bun run build",
 		"deploy": "echo 'Run \"npm run qwik add\" to install a server adapter'",
 		"docker.build": "docker buildx build --platform linux/amd64 -t furlingene/qwik-aesthetic:staging-newcal-v11 . --push",
 		"dev": "vite --mode ssr",
@@ -46,7 +47,7 @@
 		"qwik-speak": "^0.23.2",
 		"typescript": "5.4.5",
 		"typescript-plugin-css-modules": "latest",
-		"undici": "^7.24.5",
+		"undici": "^7.24.6",
 		"vite": "7.1.11",
 		"vite-tsconfig-paths": "^4.3.2"
 	},
@@ -58,7 +59,7 @@
 		"tailwindcss-animate": "^1.0.7"
 	},
 	"lint-staged": {
-		"*.{js,ts,tsx,json,css}": [
+		"*.{js,ts,tsx,json,css,md,yml,yaml}": [
 			"biome check --fix"
 		]
 	}

--- a/plans/README.md
+++ b/plans/README.md
@@ -1,0 +1,23 @@
+# Planning Workflow
+
+Use `plans/` for any task larger than a one-file fix.
+
+## Loop
+
+1. Claude Code writes or updates the plan.
+2. Codex reviews the plan against the codebase and appends `## Codex Findings`.
+3. Claude Code implements phase by phase.
+4. Codex verifies the result with fresh command output.
+
+## Plan Minimum
+
+- Goal
+- Scope or non-goals
+- Assumptions
+- Small ordered tasks
+- Verification
+
+## Verification
+
+- Substantial changes: `bun run verify`
+- Docs-only or workflow-only changes: `bun run biome`

--- a/plans/ai-agent-adoption.md
+++ b/plans/ai-agent-adoption.md
@@ -1,0 +1,72 @@
+# AI Agent Workflow Adoption
+
+## Goal
+
+Adopt a tool-native Claude Code + Codex workflow for this repository without changing application behavior.
+
+## Scope
+
+- add the baseline `.claude/` surface for shared Claude Code workflows
+- add a minimal `.codex/` surface for Codex-specific guidance
+- add shared MCP configuration
+- formalize durable plans in `plans/`
+- align `README.md`, `CLAUDE.md`, `AGENTS.md`, and `REVIEW.md`
+- align PR verification with the documented workflow
+
+## Non-Goals
+
+- no UI or runtime behavior changes
+- no dependency upgrades beyond workflow support
+- no heavy hook automation in the first rollout
+- no agent-team-by-default workflow
+
+## Assumptions
+
+- Claude Code remains the primary planner and implementer for this repo
+- Codex is used as the second-model reviewer and verifier
+- conservative MCP coverage is preferred over many integrations
+- shared docs are more important than personalized local automation
+
+## Phase 1
+
+- [x] Add durable planning guidance in `plans/README.md` and this implementation spec.
+- [x] Add baseline Claude Code settings, commands, skills, and reviewers under `.claude/`.
+- [x] Add minimal Codex project guidance under `.codex/`.
+- [x] Add `.mcp.json` with browser-testing and docs-research servers.
+- [x] Add `REVIEW.md` for review-only rules.
+- [x] Align core docs and CI with the shared workflow.
+
+## Phase 2
+
+- [ ] Add targeted hooks only for hard invariants:
+  - block React hooks in Qwik files
+  - flag hardcoded colors in UI files
+  - flag translation strings missing `@@`
+- [ ] Add more path-scoped skills if recurring work appears in loaders, UI, or release management.
+- [ ] Add `.claude/settings.local.example.json` for personal overrides that stay out of git.
+
+## Phase 3
+
+- [ ] Evaluate managed Claude Code review on pull requests using `REVIEW.md`.
+- [ ] Add a repo-specific PR template that asks for plan path, verification evidence, and doc updates.
+- [ ] Add CODEOWNERS if the team wants explicit review ownership for workflow files.
+
+## Decisions
+
+- Keep `AGENTS.md` as the canonical project policy instead of moving policy into generated command files.
+- Keep `CLAUDE.md` short and pointer-based instead of turning it into a second large rule file.
+- Use subagents before agent teams because this repo’s work is usually sequential and file-coupled.
+- Keep MCP narrow in phase 1 to reduce tool noise and permission complexity.
+- Enforce reality with CI and `REVIEW.md`, not only with prose documentation.
+
+## Verification
+
+- `bun run biome`
+- `bun run verify`
+
+## Done When
+
+- the repo has a committed Claude/Codex workflow surface
+- planning and verification expectations are durable and discoverable
+- CI reflects the documented workflow
+- future workflow changes have a clear place to live


### PR DESCRIPTION
Add a lightweight Claude Code + Codex workflow to the repo and reduce duplicated agent guidance.

This keeps AGENTS.md as the canonical policy file, turns CLAUDE.md into a thin entrypoint, adds shared workflow surfaces under .claude/ and .codex/, and documents a reusable prompt pack for planning, implementation, and verification.

It also aligns the repo verification path by adding bun run verify and expanding the PR quality workflow to run Biome, typecheck, and build checks.

Key changes:
- add .claude/, .codex/, .mcp.json, REVIEW.md, and plans/ workflow docs
- add docs/prompt-pack.md with reusable prompts for this repo
- remove duplicated policy/context from agent-facing files
- expand CI verification for pull requests