### PR TITLE
Fix staging deployment bootstrap

### DIFF
--- a/.github/DATA_LOADING.md
+++ b/.github/DATA_LOADING.md
@@ -279,7 +279,7 @@ export interface Service {
 | `SUPABASE_KEY` | Environment-specific Supabase publishable/anon key; privileged keys are prohibited | Yes |
 
 These are accessed at runtime via `event.env.get()` inside `routeLoader$` handlers. They are not baked into the client bundle.
-Staging and production use separate projects and Secret Manager secrets. Runtime readiness rejects legacy `service_role` JWTs and `sb_secret_*` keys.
+Staging and production share one read-only Supabase project but use separate Secret Manager secrets and independently pinned versions. Runtime readiness rejects legacy `service_role` JWTs and `sb_secret_*` keys.
 
 For local development, set them in your shell environment or a `.env` file (Vite loads `.env` files automatically).
 

--- a/.github/DEPLOYMENT.md
+++ b/.github/DEPLOYMENT.md
@@ -25,7 +25,7 @@ Repository/environment configuration:
 | Each environment | `GCP_WORKLOAD_ID_PROVIDER`, `GCP_SERVICE_ACCOUNT` |
 
 Store configuration at the narrowest applicable scope. WIF resource names and service-account emails are identifiers, not secrets; no private key is stored in GitHub.
-Store the alert recipient as the repository secret `ALERT_NOTIFICATION_EMAIL`. Supabase runtime keys remain only in GCP Secret Manager and are never copied into GitHub Actions.
+Store only non-sensitive Monitoring channel resource names in the repository variable `MONITORING_NOTIFICATION_CHANNEL_IDS` as a JSON list. Keep recipient addresses inside GCP notification channels so they never enter GitHub, OpenTofu plans, or state. Supabase runtime keys remain only in GCP Secret Manager and are never copied into GitHub Actions.
 
 ## Container
 

--- a/.github/DEPLOYMENT.md
+++ b/.github/DEPLOYMENT.md
@@ -25,6 +25,7 @@ Repository/environment configuration:
 | Each environment | `GCP_WORKLOAD_ID_PROVIDER`, `GCP_SERVICE_ACCOUNT` |
 
 Store configuration at the narrowest applicable scope. WIF resource names and service-account emails are identifiers, not secrets; no private key is stored in GitHub.
+Store the alert recipient as the repository secret `ALERT_NOTIFICATION_EMAIL`. Supabase runtime keys remain only in GCP Secret Manager and are never copied into GitHub Actions.
 
 ## Container
 

--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -35,7 +35,7 @@ jobs:
       TF_VAR_staging_supabase_secret_version: ${{ vars.STAGING_SUPABASE_SECRET_VERSION }}
       TF_VAR_production_supabase_url: ${{ vars.PRODUCTION_SUPABASE_URL }}
       TF_VAR_production_supabase_secret_version: ${{ vars.PRODUCTION_SUPABASE_SECRET_VERSION }}
-      TF_VAR_notification_email: ${{ vars.ALERT_NOTIFICATION_EMAIL }}
+      TF_VAR_notification_email: ${{ secrets.ALERT_NOTIFICATION_EMAIL }}
     steps:
       - name: Require staging workflow ref and complete inputs
         env:
@@ -99,7 +99,7 @@ jobs:
       TF_VAR_staging_supabase_secret_version: ${{ vars.STAGING_SUPABASE_SECRET_VERSION }}
       TF_VAR_production_supabase_url: ${{ vars.PRODUCTION_SUPABASE_URL }}
       TF_VAR_production_supabase_secret_version: ${{ vars.PRODUCTION_SUPABASE_SECRET_VERSION }}
-      TF_VAR_notification_email: ${{ vars.ALERT_NOTIFICATION_EMAIL }}
+      TF_VAR_notification_email: ${{ secrets.ALERT_NOTIFICATION_EMAIL }}
     steps:
       - name: Checkout exact planned revision
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6

--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -35,7 +35,7 @@ jobs:
       TF_VAR_staging_supabase_secret_version: ${{ vars.STAGING_SUPABASE_SECRET_VERSION }}
       TF_VAR_production_supabase_url: ${{ vars.PRODUCTION_SUPABASE_URL }}
       TF_VAR_production_supabase_secret_version: ${{ vars.PRODUCTION_SUPABASE_SECRET_VERSION }}
-      TF_VAR_notification_email: ${{ secrets.ALERT_NOTIFICATION_EMAIL }}
+      TF_VAR_notification_channel_ids: ${{ vars.MONITORING_NOTIFICATION_CHANNEL_IDS }}
     steps:
       - name: Require staging workflow ref and complete inputs
         env:
@@ -43,7 +43,7 @@ jobs:
           DEPLOYER_SERVICE_ACCOUNT: ${{ vars.GCP_SERVICE_ACCOUNT }}
         run: |
           [[ "$GITHUB_REF" == "refs/heads/staging" ]]
-          for name in TF_STATE_BUCKET TF_STATE_PREFIX TF_VAR_project_id TF_VAR_region TF_VAR_initial_image TF_VAR_staging_supabase_url TF_VAR_staging_supabase_secret_version TF_VAR_production_supabase_url TF_VAR_production_supabase_secret_version TF_VAR_notification_email WIF_PROVIDER DEPLOYER_SERVICE_ACCOUNT; do
+          for name in TF_STATE_BUCKET TF_STATE_PREFIX TF_VAR_project_id TF_VAR_region TF_VAR_initial_image TF_VAR_staging_supabase_url TF_VAR_staging_supabase_secret_version TF_VAR_production_supabase_url TF_VAR_production_supabase_secret_version TF_VAR_notification_channel_ids WIF_PROVIDER DEPLOYER_SERVICE_ACCOUNT; do
             [[ -n "${!name:-}" ]] || { echo "Missing required infrastructure variable: $name" >&2; exit 1; }
           done
 
@@ -99,7 +99,7 @@ jobs:
       TF_VAR_staging_supabase_secret_version: ${{ vars.STAGING_SUPABASE_SECRET_VERSION }}
       TF_VAR_production_supabase_url: ${{ vars.PRODUCTION_SUPABASE_URL }}
       TF_VAR_production_supabase_secret_version: ${{ vars.PRODUCTION_SUPABASE_SECRET_VERSION }}
-      TF_VAR_notification_email: ${{ secrets.ALERT_NOTIFICATION_EMAIL }}
+      TF_VAR_notification_channel_ids: ${{ vars.MONITORING_NOTIFICATION_CHANNEL_IDS }}
     steps:
       - name: Checkout exact planned revision
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@
 - Production promotion is triggered by a published release, environment-protected, smoke-tested before traffic migration, and reversible to a prior Cloud Run revision.
 - Manage Cloud Run, dedicated least-privilege service accounts, secret bindings, WIF, monitoring, and alerts in `infra/`; after bootstrap, apply only a saved plan through the protected `infrastructure` workflow and never create console-only drift.
 - Never expose secrets in source, workflow inputs, image layers, plans, logs, or CLI arguments. Scope Secret Manager access to individual environment secrets; application runtimes may use only Supabase publishable/anon keys, never `service_role` or `sb_secret_*`.
+- Keep notification recipient addresses outside OpenTofu plans and state; bootstrap channels securely in GCP and reference only their non-sensitive resource names from IaC.
 
 ## Git and Commit Attribution
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -21,7 +21,7 @@
 6. Add the shared project's publishable/anon key to both environment-specific secrets through Secret Manager. Never use `service_role` or `sb_secret_*` keys in this application. Separate secrets preserve independent IAM and version promotion even when their value is initially identical.
 7. Push an immutable bootstrap image and set `initial_image` to its GAR digest. Existing services must be imported with their current immutable GAR digest.
 8. Run `tofu plan -out=tfplan`, review replacement/IAM/public-access changes, then apply the initial saved plan with the bootstrap identity.
-9. Add `github_repository_variables` plus the state, image, and Supabase URL/version values below as repository variables. Add the alert email as the `ALERT_NOTIFICATION_EMAIL` repository secret. Add each `github_environment_variables` output to its matching environment.
+9. Bootstrap at least one Monitoring notification channel outside OpenTofu state, then add its non-sensitive full resource name to the `MONITORING_NOTIFICATION_CHANNEL_IDS` repository variable as a JSON list. Keep recipient addresses out of GitHub, plans, and state. Add `github_repository_variables` plus the state, image, and Supabase URL/version values below as repository variables. Add each `github_environment_variables` output to its matching environment.
 10. Grant the `infrastructure-plan` service account bucket-scoped `roles/storage.objectViewer`; grant the protected `infrastructure` service account bucket-scoped `roles/storage.objectAdmin` for state locking and writes.
 11. Configure required reviewers on `production` and `infrastructure`; restrict `infrastructure-plan` and `infrastructure` to `staging`; require PR/security checks on `staging` before enabling deployer variables.
 
@@ -37,9 +37,9 @@ Infrastructure workflow variables:
 | `INITIAL_IMAGE` | Immutable GAR digest used only for bootstrap/import reconciliation |
 | `STAGING_SUPABASE_URL`, `PRODUCTION_SUPABASE_URL` | Supabase project URLs; they may be identical for this read-only site |
 | `STAGING_SUPABASE_SECRET_VERSION`, `PRODUCTION_SUPABASE_SECRET_VERSION` | Tested numeric versions |
-| `ALERT_NOTIFICATION_EMAIL` | Repository secret containing the address for the OpenTofu-managed primary alert channel |
+| `MONITORING_NOTIFICATION_CHANNEL_IDS` | JSON list of existing Monitoring notification channel resource names |
 
-Optional additional channels can be supplied through `additional_notification_channel_ids` in local bootstrap variables.
+Notification channel recipients are sensitive bootstrap data. OpenTofu manages alert policies and references channels by resource name, but deliberately does not manage notification-channel recipient configuration.
 
 This root creates secret containers but never secret values or versions. Add keys directly through Secret Manager and grant secret administration only to the bootstrap/rotation identity. Rotate staging first, validate it, then pin the tested numeric production version; deployments never follow `latest`.
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -21,7 +21,7 @@
 6. Add the shared project's publishable/anon key to both environment-specific secrets through Secret Manager. Never use `service_role` or `sb_secret_*` keys in this application. Separate secrets preserve independent IAM and version promotion even when their value is initially identical.
 7. Push an immutable bootstrap image and set `initial_image` to its GAR digest. Existing services must be imported with their current immutable GAR digest.
 8. Run `tofu plan -out=tfplan`, review replacement/IAM/public-access changes, then apply the initial saved plan with the bootstrap identity.
-9. Add `github_repository_variables` plus the state, image, Supabase URL/version, and alert-email values below as repository variables. Add each `github_environment_variables` output to its matching environment.
+9. Add `github_repository_variables` plus the state, image, and Supabase URL/version values below as repository variables. Add the alert email as the `ALERT_NOTIFICATION_EMAIL` repository secret. Add each `github_environment_variables` output to its matching environment.
 10. Grant the `infrastructure-plan` service account bucket-scoped `roles/storage.objectViewer`; grant the protected `infrastructure` service account bucket-scoped `roles/storage.objectAdmin` for state locking and writes.
 11. Configure required reviewers on `production` and `infrastructure`; restrict `infrastructure-plan` and `infrastructure` to `staging`; require PR/security checks on `staging` before enabling deployer variables.
 
@@ -37,7 +37,7 @@ Infrastructure workflow variables:
 | `INITIAL_IMAGE` | Immutable GAR digest used only for bootstrap/import reconciliation |
 | `STAGING_SUPABASE_URL`, `PRODUCTION_SUPABASE_URL` | Supabase project URLs; they may be identical for this read-only site |
 | `STAGING_SUPABASE_SECRET_VERSION`, `PRODUCTION_SUPABASE_SECRET_VERSION` | Tested numeric versions |
-| `ALERT_NOTIFICATION_EMAIL` | Address for the OpenTofu-managed primary alert channel |
+| `ALERT_NOTIFICATION_EMAIL` | Repository secret containing the address for the OpenTofu-managed primary alert channel |
 
 Optional additional channels can be supplied through `additional_notification_channel_ids` in local bootstrap variables.
 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -537,8 +537,8 @@ resource "google_monitoring_alert_policy" "instance_saturation" {
     display_name = "Active instances at configured maximum"
     condition_threshold {
       filter          = "resource.type = \"cloud_run_revision\" AND resource.labels.service_name = \"${var.production_service_name}\" AND metric.type = \"run.googleapis.com/container/instance_count\" AND metric.labels.state = \"active\""
-      comparison      = "COMPARISON_GE"
-      threshold_value = var.production_max_instances
+      comparison      = "COMPARISON_GT"
+      threshold_value = var.production_max_instances - 1
       duration        = "300s"
 
       aggregations {

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -37,6 +37,13 @@ locals {
     infrastructure-plan = "assertion.repository == '${var.github_repository}' && assertion.repository_owner_id == '${var.github_repository_owner_id}' && assertion.sub == 'repo:${var.github_repository}:environment:infrastructure-plan' && assertion.ref == 'refs/heads/staging'"
   }
 
+  github_provider_display_names = {
+    staging             = "Aesthetic Lab staging"
+    production          = "Aesthetic Lab production"
+    infrastructure      = "Aesthetic Lab infrastructure"
+    infrastructure-plan = "Aesthetic Lab infra plan"
+  }
+
   iac_project_roles = toset([
     "roles/artifactregistry.admin",
     "roles/iam.serviceAccountAdmin",
@@ -120,7 +127,7 @@ resource "google_iam_workload_identity_pool_provider" "github" {
   project                            = var.project_id
   workload_identity_pool_id          = google_iam_workload_identity_pool.github.workload_identity_pool_id
   workload_identity_pool_provider_id = "github-${each.key}"
-  display_name                       = "Aesthetic Lab ${each.key}"
+  display_name                       = local.github_provider_display_names[each.key]
 
   attribute_mapping = {
     "google.subject"                = "assertion.sub"
@@ -176,17 +183,17 @@ resource "google_project_iam_member" "iac_plan" {
 }
 
 resource "google_secret_manager_secret_iam_member" "runtime_access" {
-  for_each = google_service_account.runtime
+  for_each = local.services
 
   secret_id = google_secret_manager_secret.supabase_key[each.key].id
   role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${each.value.email}"
+  member    = "serviceAccount:${google_service_account.runtime[each.key].email}"
 }
 
 resource "google_service_account_iam_member" "github_wif" {
-  for_each = google_service_account.deployer
+  for_each = local.services
 
-  service_account_id = each.value.name
+  service_account_id = google_service_account.deployer[each.key].name
   role               = "roles/iam.workloadIdentityUser"
   member             = "principal://iam.googleapis.com/${google_iam_workload_identity_pool.github.name}/subject/repo:${var.github_repository}:environment:${each.key}"
 
@@ -226,17 +233,17 @@ resource "google_artifact_registry_repository_iam_member" "production_deployer_r
 }
 
 resource "google_service_account_iam_member" "deployer_act_as" {
-  for_each = google_service_account.runtime
+  for_each = local.services
 
-  service_account_id = each.value.name
+  service_account_id = google_service_account.runtime[each.key].name
   role               = "roles/iam.serviceAccountUser"
   member             = "serviceAccount:${google_service_account.deployer[each.key].email}"
 }
 
 resource "google_service_account_iam_member" "iac_act_as" {
-  for_each = google_service_account.runtime
+  for_each = local.services
 
-  service_account_id = each.value.name
+  service_account_id = google_service_account.runtime[each.key].name
   role               = "roles/iam.serviceAccountUser"
   member             = "serviceAccount:${google_service_account.iac.email}"
 }
@@ -329,21 +336,21 @@ resource "google_cloud_run_v2_service" "web" {
 }
 
 resource "google_cloud_run_v2_service_iam_member" "public" {
-  for_each = var.allow_public_access ? google_cloud_run_v2_service.web : {}
+  for_each = var.allow_public_access ? local.services : {}
 
   project  = var.project_id
-  location = each.value.location
-  name     = each.value.name
+  location = google_cloud_run_v2_service.web[each.key].location
+  name     = google_cloud_run_v2_service.web[each.key].name
   role     = "roles/run.invoker"
   member   = "allUsers"
 }
 
 resource "google_cloud_run_v2_service_iam_member" "deployer" {
-  for_each = google_cloud_run_v2_service.web
+  for_each = local.services
 
   project  = var.project_id
-  location = each.value.location
-  name     = each.value.name
+  location = google_cloud_run_v2_service.web[each.key].location
+  name     = google_cloud_run_v2_service.web[each.key].name
   role     = "roles/run.developer"
   member   = "serviceAccount:${google_service_account.deployer[each.key].email}"
 }

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -355,17 +355,6 @@ resource "google_cloud_run_v2_service_iam_member" "deployer" {
   member   = "serviceAccount:${google_service_account.deployer[each.key].email}"
 }
 
-resource "google_monitoring_notification_channel" "email" {
-  display_name = "Aesthetic Lab production alerts"
-  type         = "email"
-  enabled      = true
-  labels = {
-    email_address = var.notification_email
-  }
-
-  depends_on = [google_project_service.required]
-}
-
 resource "google_monitoring_uptime_check_config" "localized_page" {
   display_name = "Aesthetic Lab production /en-BE/"
   timeout      = "10s"
@@ -421,7 +410,7 @@ resource "google_monitoring_uptime_check_config" "supabase_dependency" {
 resource "google_monitoring_alert_policy" "server_errors" {
   display_name          = "Aesthetic Lab production 5xx responses"
   combiner              = "OR"
-  notification_channels = concat([google_monitoring_notification_channel.email.name], var.additional_notification_channel_ids)
+  notification_channels = var.notification_channel_ids
 
   conditions {
     display_name = "5xx response rate is non-zero"
@@ -452,7 +441,7 @@ resource "google_monitoring_alert_policy" "server_errors" {
 resource "google_monitoring_alert_policy" "localized_page" {
   display_name          = "Aesthetic Lab production page or dependency unavailable"
   combiner              = "OR"
-  notification_channels = concat([google_monitoring_notification_channel.email.name], var.additional_notification_channel_ids)
+  notification_channels = var.notification_channel_ids
 
   conditions {
     display_name = "Localized page check fails"
@@ -500,7 +489,7 @@ resource "google_monitoring_alert_policy" "localized_page" {
 resource "google_monitoring_alert_policy" "latency" {
   display_name          = "Aesthetic Lab production p95 latency"
   combiner              = "OR"
-  notification_channels = concat([google_monitoring_notification_channel.email.name], var.additional_notification_channel_ids)
+  notification_channels = var.notification_channel_ids
 
   conditions {
     display_name = "p95 request latency exceeds two seconds"
@@ -531,7 +520,7 @@ resource "google_monitoring_alert_policy" "latency" {
 resource "google_monitoring_alert_policy" "instance_saturation" {
   display_name          = "Aesthetic Lab production instance saturation"
   combiner              = "OR"
-  notification_channels = concat([google_monitoring_notification_channel.email.name], var.additional_notification_channel_ids)
+  notification_channels = var.notification_channel_ids
 
   conditions {
     display_name = "Active instances at configured maximum"
@@ -562,7 +551,7 @@ resource "google_monitoring_alert_policy" "instance_saturation" {
 resource "google_monitoring_alert_policy" "runtime_failure" {
   display_name          = "Aesthetic Lab production runtime failure"
   combiner              = "OR"
-  notification_channels = concat([google_monitoring_notification_channel.email.name], var.additional_notification_channel_ids)
+  notification_channels = var.notification_channel_ids
 
   conditions {
     display_name = "Cloud Run reports memory, startup, or termination failure"
@@ -582,7 +571,7 @@ resource "google_monitoring_alert_policy" "runtime_failure" {
 resource "google_monitoring_alert_policy" "supabase_failure" {
   display_name          = "Aesthetic Lab production Supabase loader failure"
   combiner              = "OR"
-  notification_channels = concat([google_monitoring_notification_channel.email.name], var.additional_notification_channel_ids)
+  notification_channels = var.notification_channel_ids
 
   conditions {
     display_name = "Application reports Supabase fetch or configuration failure"
@@ -602,7 +591,7 @@ resource "google_monitoring_alert_policy" "supabase_failure" {
 resource "google_monitoring_alert_policy" "unexpected_production_mutation" {
   display_name          = "Aesthetic Lab unexpected production Cloud Run mutation"
   combiner              = "OR"
-  notification_channels = concat([google_monitoring_notification_channel.email.name], var.additional_notification_channel_ids)
+  notification_channels = var.notification_channel_ids
 
   conditions {
     display_name = "Production changed outside delivery or protected IaC identities"

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -16,14 +16,13 @@ output "service_urls" {
 
 output "github_repository_variables" {
   value = {
-    GCP_PROJECT              = var.project_id
-    GCP_REGION               = var.region
-    GAR_REPOSITORY           = google_artifact_registry_repository.containers.repository_id
-    IMAGE_NAME               = var.image_name
-    STAGE_SERVICE            = var.staging_service_name
-    PROD_SERVICE             = var.production_service_name
-    PROD_URL                 = "https://${var.production_uptime_host}"
-    ALERT_NOTIFICATION_EMAIL = var.notification_email
+    GCP_PROJECT    = var.project_id
+    GCP_REGION     = var.region
+    GAR_REPOSITORY = google_artifact_registry_repository.containers.repository_id
+    IMAGE_NAME     = var.image_name
+    STAGE_SERVICE  = var.staging_service_name
+    PROD_SERVICE   = var.production_service_name
+    PROD_URL       = "https://${var.production_uptime_host}"
   }
 }
 

--- a/infra/terraform.tfvars.example
+++ b/infra/terraform.tfvars.example
@@ -6,7 +6,8 @@ staging_supabase_secret_version      = "1"
 production_supabase_url              = "https://example.supabase.co"
 production_supabase_secret_version   = "1"
 
-notification_email = "alerts@example.com"
-
-# Optional existing PagerDuty, Slack, or additional email channels.
-additional_notification_channel_ids = []
+# Bootstrap notification channels outside OpenTofu state so recipient addresses
+# never enter plans or state. Only non-sensitive resource names belong here.
+notification_channel_ids = [
+  "projects/PROJECT_ID/notificationChannels/CHANNEL_ID",
+]

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -157,6 +157,11 @@ variable "production_min_instances" {
 variable "production_max_instances" {
   type    = number
   default = 3
+
+  validation {
+    condition     = var.production_max_instances >= 1
+    error_message = "production_max_instances must be at least 1."
+  }
 }
 
 variable "container_concurrency" {

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -111,20 +111,20 @@ variable "github_repository_owner_id" {
   default     = "19622412"
 }
 
-variable "notification_email" {
-  description = "Email address for the managed production alert channel."
-  type        = string
+variable "notification_channel_ids" {
+  description = "Existing Monitoring notification channel resource names used by production alerts."
+  type        = list(string)
 
   validation {
-    condition     = can(regex("^[^@[:space:]]+@[^@[:space:]]+[.][^@[:space:]]+$", var.notification_email))
-    error_message = "notification_email must be a valid email address."
+    condition = (
+      length(var.notification_channel_ids) > 0 &&
+      alltrue([
+        for channel_id in var.notification_channel_ids :
+        can(regex("^projects/[^/]+/notificationChannels/[^/]+$", channel_id))
+      ])
+    )
+    error_message = "notification_channel_ids must contain at least one full Monitoring notification channel resource name."
   }
-}
-
-variable "additional_notification_channel_ids" {
-  description = "Optional existing Monitoring notification channel resource names."
-  type        = list(string)
-  default     = []
 }
 
 variable "allow_public_access" {


### PR DESCRIPTION
## Summary
- repair fresh-state OpenTofu iteration and WIF display-name constraints
- move alert recipient to an encrypted GitHub secret
- document the shared read-only Supabase project correctly
- align GitHub/GCP bootstrap state for the hardened deployment workflow

## Validation
- bun run verify
- bun audit --audit-level=high
- tofu fmt -check -recursive
- tofu validate
- full live plan: 14 add, 2 in-place, 0 destroy
- markdownlint and git diff --check

## Live bootstrap
- dedicated GAR, WIF providers, runtime/deployer/IaC identities created
- imported existing staging/production Cloud Run services and new secret containers
- repository/environment variables configured; unreferenced legacy variables/secrets removed

Deployment remains intentionally gated until version 1 of SUPABASE_KEY_STAGING and SUPABASE_KEY_PRODUCTION contains the shared Supabase publishable/anon key.