### PR TITLE
Ignore Cloud Run deployment metadata drift

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -323,6 +323,9 @@ resource "google_cloud_run_v2_service" "web" {
 
   lifecycle {
     ignore_changes = [
+      client,
+      client_version,
+      template[0].revision,
       template[0].containers[0].image,
       traffic,
     ]


### PR DESCRIPTION
GitHub Actions owns revision naming and deployment client metadata alongside image and traffic. Ignore those fields so successful deployments do not create perpetual OpenTofu drift.

Co-Authored-By: GPT-5 Codex <codex@openai.com>
