### PR TITLE
Fix production canary smoke target

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -326,6 +326,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REVISION: ${{ needs.production_prepare.outputs.revision }}
           PREVIOUS: ${{ needs.production_prepare.outputs.previous }}
+          CANDIDATE_URL: ${{ needs.production_prepare.outputs.candidate_url }}
           URL: ${{ env.PROD_URL }}
         run: |
           promotion_complete=false
@@ -368,7 +369,7 @@ jobs:
 
           require_watchdog initial
           gcloud run services update-traffic "$PROD_SERVICE" --region="$GCP_REGION" --project="$GCP_PROJECT" --to-revisions="$REVISION=10,$PREVIOUS=90" --quiet
-          ./scripts/smoke-deployment.sh "$URL"
+          ./scripts/smoke-deployment.sh "$CANDIDATE_URL"
 
           CANARY_STATE=$(gcloud run services describe "$PROD_SERVICE" --region="$GCP_REGION" --project="$GCP_PROJECT" --format=json)
           test "$(jq --arg revision "$REVISION" '[.status.traffic[] | select(.revisionName == $revision and .percent == 10)] | length' <<<"$CANARY_STATE")" = "1"


### PR DESCRIPTION
## Summary
- smoke the tagged production candidate URL during 10/90 canary
- keep canonical production smoke after 100% promotion

## Verification
- bun run verify