### PR TITLE
Release 2.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "aestheticlab",
 	"description": "AestheticLab",
-	"version": "2.8.0",
+	"version": "2.8.1",
 	"packageManager": "bun@1.3.14",
 	"engines": {
 		"node": "^20.3.0 || >=21.0.0"


### PR DESCRIPTION
## Summary
- bump package metadata to 2.8.1 for a fresh immutable production release after the canary workflow fix

## Verification
- bun run verify