### PR TITLE
fix: reduce Supabase monitoring egress

### DIFF
--- a/.github/DEPLOYMENT.md
+++ b/.github/DEPLOYMENT.md
@@ -128,7 +128,7 @@ gcloud run services update-traffic SERVICE \
 
 ## Operational Checks
 
-- OpenTofu manages content-matched page/dependency uptime checks plus availability, 5xx, p95 latency, instance-saturation, memory-limit, structured Supabase-failure, and unexpected-production-mutation alerts.
+- OpenTofu manages health/dependency uptime checks plus availability, 5xx, p95 latency, instance-saturation, memory-limit, structured Supabase-failure, and unexpected-production-mutation alerts. Keep high-frequency uptime checks on lightweight endpoints; localized page checks belong in deployment smoke tests.
 - Candidate deployment smoke tests require readiness, localized content, and security headers on `/en-BE/` and `/fr-BE/pricelist/` before traffic migration.
 - Inspect Cloud Run revision logs and monitoring before shifting traffic.
 - Treat a passing `/healthz` as process health only; localized smoke tests validate the dependency path.

--- a/infra/README.md
+++ b/infra/README.md
@@ -9,7 +9,7 @@
 - Separate read-only planner and protected privileged apply identity for saved-plan OpenTofu automation
 - Secret-level publishable/anon Supabase access; service-role keys are rejected by runtime readiness
 - Cloud Run v2 services, probes, scaling, and public invocation
-- Production localized-page and Supabase-dependency uptime plus 5xx, p95 latency, instance saturation, runtime-failure, loader, and unexpected-mutation alerts
+- Production health-endpoint and Supabase-dependency uptime plus 5xx, p95 latency, instance saturation, runtime-failure, loader, and unexpected-mutation alerts
 
 ## Bootstrap
 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -359,12 +359,13 @@ resource "google_cloud_run_v2_service_iam_member" "deployer" {
 }
 
 resource "google_monitoring_uptime_check_config" "localized_page" {
-  display_name = "Aesthetic Lab production /en-BE/"
-  timeout      = "10s"
-  period       = "60s"
+  display_name     = "Aesthetic Lab production health endpoint"
+  selected_regions = ["EUROPE"]
+  timeout          = "10s"
+  period           = "60s"
 
   http_check {
-    path         = "/en-BE/"
+    path         = "/healthz"
     port         = 443
     use_ssl      = true
     validate_ssl = true
@@ -379,15 +380,16 @@ resource "google_monitoring_uptime_check_config" "localized_page" {
   }
 
   content_matchers {
-    content = "Aesthetic Lab"
+    content = "OK"
     matcher = "CONTAINS_STRING"
   }
 }
 
 resource "google_monitoring_uptime_check_config" "supabase_dependency" {
-  display_name = "Aesthetic Lab production Supabase dependency"
-  timeout      = "10s"
-  period       = "60s"
+  display_name     = "Aesthetic Lab production Supabase dependency"
+  selected_regions = ["EUROPE"]
+  timeout          = "10s"
+  period           = "300s"
 
   http_check {
     path         = "/dependencyz"
@@ -442,12 +444,12 @@ resource "google_monitoring_alert_policy" "server_errors" {
 }
 
 resource "google_monitoring_alert_policy" "localized_page" {
-  display_name          = "Aesthetic Lab production page or dependency unavailable"
+  display_name          = "Aesthetic Lab production health or dependency unavailable"
   combiner              = "OR"
   notification_channels = var.notification_channel_ids
 
   conditions {
-    display_name = "Localized page check fails"
+    display_name = "Health endpoint check fails"
     condition_threshold {
       filter          = "resource.type = \"uptime_url\" AND metric.type = \"monitoring.googleapis.com/uptime_check/check_passed\" AND metric.labels.check_id = \"${google_monitoring_uptime_check_config.localized_page.uptime_check_id}\""
       comparison      = "COMPARISON_LT"


### PR DESCRIPTION
## Summary
- move high-frequency production uptime monitoring from /en-BE/ to /healthz
- restrict uptime checks to Europe and reduce Supabase dependency polling to 5 minutes
- update deployment/infra docs to keep localized checks in deployment smoke tests

## Verification
- bun run verify
- tofu -chdir=infra fmt -check -recursive
- tofu -chdir=infra init -backend=false
- tofu -chdir=infra validate
- markdownlint --disable MD013 -- .github/DEPLOYMENT.md infra/README.md
- tofu plan -lock=false: 0 add, 3 change, 0 destroy