### PR TITLE
test(e2e): Mock SSR catalogue in CI

### DIFF
--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -98,7 +98,7 @@ test("keeps the Instagram profile card compact on desktop and fluid on mobile", 
 
 		if (viewport.width >= 1024) {
 			expect(metrics.width).toBeLessThanOrEqual(1024);
-			expect(metrics.height).toBeLessThanOrEqual(448);
+			expect(metrics.height).toBeLessThanOrEqual(448.5);
 			expect(metrics.left).toBeCloseTo(
 				(metrics.viewportWidth - metrics.width) / 2,
 				0,
@@ -175,10 +175,6 @@ test("opens treatments in-page and restores the overview with browser history", 
 	await page.goto("/en-BE/#services");
 
 	const treatmentButtons = page.getByRole("button", { name: "View Treatments" });
-	test.skip(
-		(await treatmentButtons.count()) === 0,
-		"Requires an available service catalogue",
-	);
 	await expect(treatmentButtons).toHaveCount(4);
 	await treatmentButtons.first().click();
 
@@ -198,10 +194,6 @@ test("falls back to the treatment overview for invalid shared state", async ({
 	);
 
 	const treatmentButtons = page.getByRole("button", { name: "View Treatments" });
-	test.skip(
-		(await treatmentButtons.count()) === 0,
-		"Requires an available service catalogue",
-	);
 	await expect(treatmentButtons).toHaveCount(4);
 	await expect(page.locator("#service-details-heading")).toHaveCount(0);
 	await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(

--- a/e2e/mock-supabase.ts
+++ b/e2e/mock-supabase.ts
@@ -1,0 +1,58 @@
+const serviceGroups = [
+	{ id: "manicure", name: "Manicure", priority: 40 },
+	{ id: "pedicure", name: "Pedicure", priority: 30 },
+	{ id: "brows", name: "Brows & Lashes", priority: 20 },
+	{ id: "laser-face", name: "Laser Hair Removal Face", priority: 10 },
+].map((group) => ({
+	...group,
+	active: true,
+	name_en: group.name,
+	name_fr: group.name,
+	name_nl: group.name,
+	name_ru: group.name,
+	name_uk: group.name,
+}));
+
+const services = serviceGroups.map((group, index) => ({
+	id: `service-${index + 1}`,
+	group_id: group.id,
+	category: group.name,
+	name: `${group.name} service`,
+	name_fr: "",
+	name_nl: "",
+	name_ru: "",
+	name_uk: "",
+	description: `${group.name} treatment description`,
+	description_fr: "",
+	description_nl: "",
+	description_ru: "",
+	description_uk: "",
+	duration: 60,
+	price: 50 + index * 10,
+	priority: group.priority,
+	active: true,
+}));
+
+function json(data: unknown) {
+	return Response.json(data, {
+		headers: {
+			"Content-Range": "0-*/*",
+		},
+	});
+}
+
+Bun.serve({
+	hostname: "127.0.0.1",
+	port: 43121,
+	fetch(request) {
+		const { pathname } = new URL(request.url);
+
+		if (pathname === "/health") return json({ status: "ok" });
+		if (pathname === "/rest/v1/service_groups") return json(serviceGroups);
+		if (pathname === "/rest/v1/services") return json(services);
+		if (pathname === "/rest/v1/contacts") return json(null);
+		if (pathname === "/rest/v1/staff") return json([]);
+
+		return new Response("Not found", { status: 404 });
+	},
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,30 @@
 import { defineConfig, devices } from "@playwright/test";
 
+const mockSupabaseUrl = "http://127.0.0.1:43121";
+const webServers = [
+	...(process.env.CI
+		? [
+				{
+					command: "bun e2e/mock-supabase.ts",
+					name: "Mock Supabase",
+					reuseExistingServer: false,
+					url: `${mockSupabaseUrl}/health`,
+				},
+			]
+		: []),
+	{
+		command: "bun run dev",
+		env: process.env.CI
+			? {
+					SUPABASE_KEY: "sb_publishable_ci_placeholder",
+					SUPABASE_URL: mockSupabaseUrl,
+				}
+			: undefined,
+		reuseExistingServer: !process.env.CI,
+		url: "http://localhost:5173",
+	},
+];
+
 export default defineConfig({
 	testDir: "./e2e",
 	fullyParallel: false,
@@ -25,9 +50,5 @@ export default defineConfig({
 			use: { ...devices["Desktop Safari"] },
 		},
 	],
-	webServer: {
-		command: "bun run dev",
-		url: "http://localhost:5173",
-		reuseExistingServer: !process.env.CI,
-	},
+	webServer: webServers,
 });


### PR DESCRIPTION
## Summary

- serve deterministic PostgREST-compatible catalogue fixtures during CI Playwright runs
- route Qwik SSR loaders to the fixture server
- execute treatment URL-state smoke tests instead of skipping them
- tolerate sub-pixel browser rounding in the Instagram card height assertion

## Verification

- `bun run verify`
- `CI=1 bunx playwright test --project=chromium` — 16 passed