### PR TITLE
fix(ui): Stabilize mobile treatment navigation

### DIFF
--- a/.github/DAISYUI_PATTERNS.md
+++ b/.github/DAISYUI_PATTERNS.md
@@ -164,16 +164,13 @@ Used for the language switcher:
 Used in the reviews section:
 
 ```tsx
-<div class="rating rating-sm gap-0.5" aria-label="5 out of 5 stars">
+<div class="rating rating-sm gap-0.5" role="img" aria-label="5 out of 5 stars">
   {[1, 2, 3, 4, 5].map((i) => (
-    <input
+    <div
       key={i}
-      type="radio"
-      name={`rating-${uniqueIndex}`}
       class="mask mask-star-2 bg-warning"
-      aria-label={`${i} star${i > 1 ? "s" : ""}`}
-      checked
-      disabled
+      aria-hidden="true"
+      aria-current={i === 5 ? "true" : undefined}
     />
   ))}
 </div>
@@ -181,9 +178,11 @@ Used in the reviews section:
 
 ### Rating Conventions
 
-- Display-only ratings use `checked disabled` on all inputs.
+- Display-only ratings use non-interactive elements and mark the selected value with `aria-current="true"`.
+- The selected value makes it and every preceding star fully opaque; without it daisyUI intentionally renders stars at 20% opacity.
+- Expose the group as one localized `role="img"` label and hide the decorative star elements from assistive technology.
 - Star color: `bg-warning` (golden).
-- Each rating group needs a unique `name` to avoid radio button conflicts.
+- Interactive ratings use radio inputs with a unique `name`; do not use inputs for display-only ratings.
 
 ## Links (`link`)
 

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -51,6 +51,16 @@ test("keeps the hero as the complete first viewport", async ({ page }) => {
 	expect(heroHeight).toBeGreaterThanOrEqual(viewportHeight - 1);
 });
 
+test("uses a stable mobile viewport height when browser chrome changes", async ({
+	page,
+}) => {
+	await page.setViewportSize({ width: 390, height: 844 });
+	await page.goto("/en-BE/");
+
+	await expect(page.locator("#hero")).toHaveClass(/\bmin-h-svh\b/);
+	await expect(page.locator("#hero")).not.toHaveClass(/\bmin-h-dvh\b/);
+});
+
 test("supports the audited responsive widths without horizontal overflow", async ({
 	page,
 }) => {
@@ -167,11 +177,32 @@ test("uses one card radius and a non-looping review rail", async ({ page }) => {
 	expect(cardRadii).toEqual(["16px"]);
 	await expect(reviewRail.locator("article")).toHaveCount(11);
 	await expect(reviewRail).toHaveCSS("animation-name", "none");
+
+	const ratingStyles = await page
+		.getByTestId("review-rating")
+		.evaluateAll((ratings) =>
+			ratings.map((rating) => ({
+				current: rating.lastElementChild?.getAttribute("aria-current"),
+				opacities: Array.from(
+					rating.children,
+					(star) => getComputedStyle(star).opacity,
+				),
+			})),
+		);
+
+	expect(ratingStyles).toHaveLength(12);
+	expect(ratingStyles).toEqual(
+		Array.from({ length: 12 }, () => ({
+			current: "true",
+			opacities: ["1", "1", "1", "1", "1"],
+		})),
+	);
 });
 
 test("opens treatments in-page and restores the overview with browser history", async ({
 	page,
 }) => {
+	await page.setViewportSize({ width: 390, height: 844 });
 	await page.goto("/en-BE/#services");
 
 	const treatmentButtons = page.getByRole("button", { name: "View Treatments" });
@@ -181,6 +212,22 @@ test("opens treatments in-page and restores the overview with browser history", 
 	await expect(page).toHaveURL(/\?treatment=[^#]+#services$/);
 	await expect(page.locator("#service-details-heading")).toBeVisible();
 
+	const detailsCard = page.getByTestId("service-details-card");
+	const categoryButtons = detailsCard.getByRole("button");
+	await expect(categoryButtons).toHaveCount(4);
+	await categoryButtons.nth(1).click();
+
+	await expect.poll(async () => {
+		return detailsCard.evaluate((card) => {
+			const header = document.querySelector("header");
+			const cardTop = card.getBoundingClientRect().top;
+			const headerBottom = header?.getBoundingClientRect().bottom ?? 0;
+			return cardTop >= headerBottom - 1 && cardTop <= headerBottom + 32;
+		});
+	}).toBe(true);
+
+	await page.goBack();
+	await expect(page.locator("#service-details-heading")).toBeVisible();
 	await page.goBack();
 	await expect(page).toHaveURL(/\/en-BE\/#services$/);
 	await expect(treatmentButtons).toHaveCount(4);

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -226,6 +226,20 @@ test("opens treatments in-page and restores the overview with browser history", 
 		});
 	}).toBe(true);
 
+	const backActions = page.getByTestId("service-back-actions");
+	await expect(backActions.getByRole("button", { name: "Back to Overview" })).toBeVisible();
+	const verticalPositions = await page.evaluate(() => {
+		const card = document.querySelector('[data-testid="service-details-card"]');
+		const actions = document.querySelector('[data-testid="service-back-actions"]');
+		return {
+			actionsTop: actions?.getBoundingClientRect().top ?? 0,
+			cardBottom: card?.getBoundingClientRect().bottom ?? 0,
+		};
+	});
+	expect(verticalPositions.actionsTop).toBeGreaterThanOrEqual(
+		verticalPositions.cardBottom,
+	);
+
 	await page.goBack();
 	await expect(page.locator("#service-details-heading")).toBeVisible();
 	await page.goBack();

--- a/src/components/sections/hero-section.tsx
+++ b/src/components/sections/hero-section.tsx
@@ -10,7 +10,7 @@ export const HeroSection = component$(() => {
 	return (
 		<section
 			id="hero"
-			class="hero relative flex min-h-dvh w-full items-center justify-center overflow-hidden bg-base-200 pt-[calc(env(safe-area-inset-top)+5.25rem)] pb-10 md:pt-[calc(env(safe-area-inset-top)+6.5rem)] md:pb-16"
+			class="hero relative flex min-h-svh w-full items-center justify-center overflow-hidden bg-base-200 pt-[calc(env(safe-area-inset-top)+5.25rem)] pb-10 md:pt-[calc(env(safe-area-inset-top)+6.5rem)] md:pb-16"
 		>
 			<div class="custom-container relative z-10 flex flex-col items-center justify-center text-center">
 				{/* Main Headline Group */}

--- a/src/components/sections/reviews-section.tsx
+++ b/src/components/sections/reviews-section.tsx
@@ -99,14 +99,19 @@ export const ReviewsSection = component$(() => {
 					</div>
 					<div class="flex flex-col items-center gap-2 lg:items-end">
 						<div class="flex items-center justify-center gap-2">
-							<span class="sr-only">
-								{t("app.reviews.rating_aria@@5 out of 5 stars")}
-							</span>
-							{/* 5 Stars SVG */}
-							{/* 5 Stars DaisyUI */}
-							<div class="rating rating-md gap-1" aria-hidden="true">
+							<div
+								class="rating rating-md gap-1"
+								data-testid="review-rating"
+								role="img"
+								aria-label={t("app.reviews.rating_aria@@5 out of 5 stars")}
+							>
 								{[1, 2, 3, 4, 5].map((i) => (
-									<span key={i} class="mask mask-star-2 size-5 bg-warning" />
+									<div
+										key={i}
+										class="mask mask-star-2 size-5 bg-warning"
+										aria-hidden="true"
+										aria-current={i === 5 ? "true" : undefined}
+									/>
 								))}
 							</div>
 							<span class="font-montserrat font-medium">5.0</span>
@@ -141,17 +146,18 @@ export const ReviewsSection = component$(() => {
 								class="surface-card flex w-[min(18rem,calc(100vw-3rem))] shrink-0 snap-start flex-col justify-between p-5 sm:w-80 md:w-96 md:p-6"
 							>
 								<div>
-									<span class="sr-only">
-										{t("app.reviews.rating_aria@@5 out of 5 stars")}
-									</span>
 									<div
 										class="rating rating-xs mb-3 gap-0.5 md:rating-sm md:mb-4"
-										aria-hidden="true"
+										data-testid="review-rating"
+										role="img"
+										aria-label={t("app.reviews.rating_aria@@5 out of 5 stars")}
 									>
 										{[1, 2, 3, 4, 5].map((i) => (
-											<span
+											<div
 												key={i}
 												class="mask mask-star-2 size-3 bg-warning md:size-4"
+												aria-hidden="true"
+												aria-current={i === review.rating ? "true" : undefined}
 											/>
 										))}
 									</div>{" "}

--- a/src/components/sections/service-grid.tsx
+++ b/src/components/sections/service-grid.tsx
@@ -30,6 +30,9 @@ interface DisplayServiceGroup extends GroupedServiceData {
 	displayTitle: string;
 }
 
+const serviceDetailsCardId = "service-details-card";
+const serviceDetailsHeadingId = "service-details-heading";
+
 function updateTreatmentUrl(categoryId?: string, subgroupId?: string) {
 	const url = new URL(window.location.href);
 
@@ -49,18 +52,19 @@ function updateTreatmentUrl(categoryId?: string, subgroupId?: string) {
 	history.pushState(null, "", url);
 }
 
-function focusServiceDetails() {
+function revealServiceDetails() {
 	requestAnimationFrame(() => {
-		document.getElementById("service-details-heading")?.focus();
-	});
-}
-
-function scrollToServices() {
-	document.getElementById("services")?.scrollIntoView({
-		behavior: window.matchMedia("(prefers-reduced-motion: reduce)").matches
-			? "auto"
-			: "smooth",
-		block: "start",
+		requestAnimationFrame(() => {
+			document.getElementById(serviceDetailsCardId)?.scrollIntoView({
+				behavior: window.matchMedia("(prefers-reduced-motion: reduce)").matches
+					? "auto"
+					: "smooth",
+				block: "start",
+			});
+			document
+				.getElementById(serviceDetailsHeadingId)
+				?.focus({ preventScroll: true });
+		});
 	});
 }
 
@@ -307,8 +311,7 @@ export const ServiceGrid = component$<ServiceGridProps>(
 				});
 
 				updateTreatmentUrl(groupId);
-				scrollToServices();
-				focusServiceDetails();
+				revealServiceDetails();
 			},
 		);
 
@@ -324,15 +327,14 @@ export const ServiceGrid = component$<ServiceGridProps>(
 				});
 
 				updateTreatmentUrl("laser", groupId);
-				scrollToServices();
-				focusServiceDetails();
+				revealServiceDetails();
 			},
 		);
 
 		const resetLaserSubgroup = $(() => {
 			selectedLaserSubgroupId.value = null;
 			updateTreatmentUrl("laser");
-			focusServiceDetails();
+			revealServiceDetails();
 		});
 
 		const restoreTreatmentState = $(() => {
@@ -409,7 +411,12 @@ export const ServiceGrid = component$<ServiceGridProps>(
 						<div class="space-y-6 md:space-y-8">
 							{activeDetailGroup.value ? (
 								<FadeUp>
-									<div class="surface-card p-4 md:p-6">
+									<section
+										id={serviceDetailsCardId}
+										data-testid={serviceDetailsCardId}
+										aria-labelledby={serviceDetailsHeadingId}
+										class="card surface-card scroll-mt-24 p-4 md:p-6"
+									>
 										<div class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
 											<div class="space-y-3 md:space-y-4">
 												<div class="flex flex-wrap gap-2">
@@ -431,7 +438,7 @@ export const ServiceGrid = component$<ServiceGridProps>(
 												</div>
 												<div>
 													<h3
-														id="service-details-heading"
+														id={serviceDetailsHeadingId}
 														tabIndex={-1}
 														class="text-balance font-qestero text-3xl leading-none text-base-content outline-none md:text-4xl"
 													>
@@ -488,7 +495,7 @@ export const ServiceGrid = component$<ServiceGridProps>(
 												})}
 											</div>
 										</nav>
-									</div>
+									</section>
 								</FadeUp>
 							) : null}
 

--- a/src/components/sections/service-grid.tsx
+++ b/src/components/sections/service-grid.tsx
@@ -385,24 +385,6 @@ export const ServiceGrid = component$<ServiceGridProps>(
 								>
 									{viewFullLabel}
 								</a>
-								{selectedLaserSubgroupId.value ? (
-									<button
-										type="button"
-										onClick$={resetLaserSubgroup}
-										class="btn btn-ghost btn-sm rounded-full font-montserrat uppercase tracking-wider text-primary"
-									>
-										{backToLaserLabel}
-									</button>
-								) : null}
-								{showFullList.value ? (
-									<button
-										type="button"
-										onClick$={resetOverview}
-										class="btn btn-ghost btn-sm rounded-full font-montserrat uppercase tracking-wider text-primary"
-									>
-										{backLabel}
-									</button>
-								) : null}
 							</div>
 						</FadeUp>
 					</div>
@@ -498,6 +480,30 @@ export const ServiceGrid = component$<ServiceGridProps>(
 									</section>
 								</FadeUp>
 							) : null}
+
+							<FadeUp delay={60}>
+								<div
+									data-testid="service-back-actions"
+									class="flex flex-wrap items-center justify-center gap-2 md:justify-end"
+								>
+									{selectedLaserSubgroupId.value ? (
+										<button
+											type="button"
+											onClick$={resetLaserSubgroup}
+											class="btn btn-ghost btn-sm rounded-full font-montserrat uppercase tracking-wider text-primary"
+										>
+											{backToLaserLabel}
+										</button>
+									) : null}
+									<button
+										type="button"
+										onClick$={resetOverview}
+										class="btn btn-ghost btn-sm rounded-full font-montserrat uppercase tracking-wider text-primary"
+									>
+										{backLabel}
+									</button>
+								</div>
+							</FadeUp>
 
 							{selectedGroup.value?.groupId === "laser" &&
 							!selectedLaserSubgroup.value ? (

--- a/src/global.css
+++ b/src/global.css
@@ -314,6 +314,6 @@ body {
   transition-duration: var(--motion-fast);
 }
 
-.rating input {
+.rating > * {
   animation-duration: var(--motion-base);
 }


### PR DESCRIPTION
## Summary
- render review ratings as fully filled DaisyUI stars
- prevent mobile browser chrome changes from resizing the hero and shifting content
- scroll treatment category changes to the detail card below the fixed header

## Verification
- `bun run verify`
- `bunx playwright test e2e/home.spec.ts --project=chromium --grep "opens treatments in-page"`
- mobile visual check at 390×844